### PR TITLE
Bug fixing

### DIFF
--- a/PListNet/Internal/ExtendedEncoding.cs
+++ b/PListNet/Internal/ExtendedEncoding.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PListNet.Internal
+{
+    internal class ExtendedEncoding : UTF8Encoding
+    {
+        public override string WebName
+        {
+            get { return base.WebName.ToUpper(); }
+        }
+
+        private ExtendedEncoding()
+        {
+        }
+
+        public static readonly ExtendedEncoding UpperCaseUTF8 = new ExtendedEncoding();
+    }
+}

--- a/PListNet/PList.cs
+++ b/PListNet/PList.cs
@@ -80,6 +80,7 @@ namespace PListNet
 			{
 				var sets = new XmlWriterSettings
 					{
+                        // Apple Web Services require encoding being uppercase
 						Encoding = ExtendedEncoding.UpperCaseUTF8,
 						Indent = true,
 						IndentChars = "\t",
@@ -89,6 +90,8 @@ namespace PListNet
 				using (var xmlWriter = XmlWriter.Create(stream, sets))
 				{
 					xmlWriter.WriteStartDocument();
+                    // Apple Web Services will not handle requests if "Apple Computer" is not
+                    // replaced by just "Apple"
 					xmlWriter.WriteDocType("plist", "-//Apple//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd", null);
 
 					// write out nodes, wrapped in plist root element

--- a/PListNet/PList.cs
+++ b/PListNet/PList.cs
@@ -80,7 +80,7 @@ namespace PListNet
 			{
 				var sets = new XmlWriterSettings
 					{
-						Encoding = Encoding.UTF8,
+						Encoding = ExtendedEncoding.UpperCaseUTF8,
 						Indent = true,
 						IndentChars = "\t",
 						NewLineChars = "\n",
@@ -89,7 +89,7 @@ namespace PListNet
 				using (var xmlWriter = XmlWriter.Create(stream, sets))
 				{
 					xmlWriter.WriteStartDocument();
-					xmlWriter.WriteDocType("plist", "-//Apple Computer//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd", null);
+					xmlWriter.WriteDocType("plist", "-//Apple//DTD PLIST 1.0//EN", "http://www.apple.com/DTDs/PropertyList-1.0.dtd", null);
 
 					// write out nodes, wrapped in plist root element
 					xmlWriter.WriteStartElement("plist");

--- a/PListNet/PNode.cs
+++ b/PListNet/PNode.cs
@@ -58,7 +58,7 @@ namespace PListNet
 		internal override void ReadXml(XmlReader reader)
 		{
             var isEmptyElement = reader.IsEmptyElement;
-			reader.ReadStartElement();
+            reader.ReadStartElement();
             if (!isEmptyElement)
             {
                 Parse(reader.ReadContentAsString());

--- a/PListNet/PNode.cs
+++ b/PListNet/PNode.cs
@@ -57,9 +57,17 @@ namespace PListNet
 		/// <param name="reader">The <see cref="T:System.Xml.XmlReader"/> stream from which the object is deserialized.</param>
 		internal override void ReadXml(XmlReader reader)
 		{
+            var isEmptyElement = reader.IsEmptyElement;
 			reader.ReadStartElement();
-			Parse(reader.ReadContentAsString());
-			reader.ReadEndElement();
+            if (!isEmptyElement)
+            {
+                Parse(reader.ReadContentAsString());
+                reader.ReadEndElement();
+            }
+            else
+            {
+                Parse(String.Empty);
+            }
 		}
 
 		/// <summary>


### PR DESCRIPTION
This fixes two bugs:

1. Apple Web Services are very strict on the PList format (e.g. utf-8 must be capitalized); making the writer compliant
2. the parser doesn't handle correctly short empty elements (e.g. <string/> vs. <string></string>)