### PR TITLE
Rework how boolean values are written in XML

### DIFF
--- a/PListNet.sln.DotSettings
+++ b/PListNet.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=ustring/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/PListNet.sln.DotSettings
+++ b/PListNet.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=typecode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ustring/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/PListNet/Nodes/BooleanNode.cs
+++ b/PListNet/Nodes/BooleanNode.cs
@@ -64,7 +64,9 @@ namespace PListNet.Nodes
 		{
 			// writing value as raw because Apple's parser expects no
 			// space before the closing tag, and the XmlWrites inserts one
-			writer.WriteRaw($"<{ToXmlString()}/>");
+			//writer.WriteRaw($"<{ToXmlString()}/>");
+			writer.WriteStartElement(ToXmlString());
+			writer.WriteEndElement();
 		}
 
 		/// <summary>

--- a/PListNet/Nodes/BooleanNode.cs
+++ b/PListNet/Nodes/BooleanNode.cs
@@ -70,7 +70,7 @@ namespace PListNet.Nodes
 		/// <summary>
 		/// Parses the specified value from a given string, read from Xml.
 		/// </summary>
-		/// <param name="data">The string whis is parsed.</param>
+		/// <param name="data">The string which is parsed.</param>
 		internal override void Parse(string data)
 		{
 			Value = data == "true";

--- a/PListNet/Tests/PListNet.Tests.csproj
+++ b/PListNet/Tests/PListNet.Tests.csproj
@@ -84,6 +84,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <EmbeddedResource Include="TestFiles\github-7-binary-2.plist" />
+    <EmbeddedResource Include="TestFiles\github-20.plist" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="LICENSE.EndianBitConverter.txt" />

--- a/PListNet/Tests/TestFiles/github-20.plist
+++ b/PListNet/Tests/TestFiles/github-20.plist
@@ -7,7 +7,7 @@
 		<key>ABool</key>
 		<true/>
 		<key>AString</key>
-		<string>Smiley 😊</string>
+		<ustring>Smiley 😊</ustring>
 		<key>AnArray</key>
 		<array>
 			<integer>13</integer>

--- a/PListNet/Tests/TestFiles/github-20.plist
+++ b/PListNet/Tests/TestFiles/github-20.plist
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Something</key>
+		<integer>42</integer>
+		<key>ABool</key>
+		<true/>
+		<key>AString</key>
+		<string>Smiley 😊</string>
+		<key>AnArray</key>
+		<array>
+			<integer>13</integer>
+			<string>and now for something else</string>
+		</array>
+	</dict>
+</plist>

--- a/PListNet/Tests/XmlWriterTests.cs
+++ b/PListNet/Tests/XmlWriterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
+using System.Text;
 using NUnit.Framework;
 using PListNet.Nodes;
-using System.Text;
 
 namespace PListNet.Tests
 {
@@ -9,7 +9,7 @@ namespace PListNet.Tests
 	public class XmlWriterTests
 	{
 		[Test]
-		public void WhenXmlFormatIsResavedAndOpened_ThenParsedDocumentMatchesTheOriginal()
+		public void WhenXmlFormatIsSavedAndOpened_ThenParsedDocumentMatchesTheOriginal()
 		{
 			using (var stream = TestFileHelper.GetTestFileStream("TestFiles/utf8-Info.plist"))
 			{
@@ -38,6 +38,8 @@ namespace PListNet.Tests
 					var oldDict = node as DictionaryNode;
 					var newDict = newNode as DictionaryNode;
 
+					Assert.NotNull(oldDict);
+					Assert.NotNull(newDict);
 					Assert.AreEqual(oldDict.Count, newDict.Count);
 
 					foreach (var key in oldDict.Keys)
@@ -70,8 +72,7 @@ namespace PListNet.Tests
 			using (var outStream = new MemoryStream())
 			{
 				// create basic PList containing a boolean value
-				var node = new DictionaryNode();
-				node.Add("Test", new BooleanNode(true));
+				var node = new DictionaryNode {{"Test", new BooleanNode(true)}};
 
 				// save and reset stream
 				PList.Save(node, outStream, PListFormat.Xml);
@@ -95,8 +96,7 @@ namespace PListNet.Tests
 				var utf16value = "😂test";
 
 				// create basic PList containing a boolean value
-				var node = new DictionaryNode();
-				node.Add("Test", new StringNode(utf16value));
+				var node = new DictionaryNode {{"Test", new StringNode(utf16value)}};
 
 				// save and reset stream
 				PList.Save(node, outStream, PListFormat.Xml);

--- a/PListNet/Tests/XmlWriterTests.cs
+++ b/PListNet/Tests/XmlWriterTests.cs
@@ -123,7 +123,6 @@ namespace PListNet.Tests
 						var contents = reader.ReadToEnd();
 
 						Assert.AreEqual(source, contents);
-						Assert.IsTrue(contents.Contains("<true/>"));
 					}
 				}
 

--- a/PListNet/Tests/XmlWriterTests.cs
+++ b/PListNet/Tests/XmlWriterTests.cs
@@ -89,6 +89,48 @@ namespace PListNet.Tests
 		}
 
 		[Test]
+		public void WhenXmlPlistWithBooleanValueIsLoadedAndSaved_ThenWhiteSpaceMatches()
+		{
+			using (var stream = TestFileHelper.GetTestFileStream("TestFiles/github-20.plist"))
+			{
+				// read in the source file and reset the stream so we can parse from it
+				string source;
+				using (var reader = new StreamReader(stream, Encoding.Default, true, 2048, true))
+				{
+					source = reader.ReadToEnd();
+				}
+				stream.Seek(0, SeekOrigin.Begin);
+
+				var root = PList.Load(stream) as DictionaryNode;
+				Assert.IsNotNull(root);
+
+				// verify that we parsed expected content
+				var node = root["ABool"] as BooleanNode;
+				Assert.IsNotNull(node);
+				Assert.IsTrue(node.Value);
+
+				// write the file out to memory and check that there is still no space
+				// in the written out boolean node
+				using (var outStream = new MemoryStream())
+				{
+					// save and reset stream
+					PList.Save(root, outStream, PListFormat.Xml);
+					outStream.Seek(0, SeekOrigin.Begin);
+
+					// check that boolean was written out without a space per spec (see also issue #11)
+					using (var reader = new StreamReader(outStream))
+					{
+						var contents = reader.ReadToEnd();
+
+						Assert.AreEqual(source, contents);
+						Assert.IsTrue(contents.Contains("<true/>"));
+					}
+				}
+
+			}
+		}
+
+		[Test]
 		public void WhenStringContainsUnicode_ThenStringIsWrappedInUstringTag()
 		{
 			using (var outStream = new MemoryStream())


### PR DESCRIPTION
Addresses the problem surfaced in #20 where writing the boolean XML element using the `WriteRaw` caused the output Plist file to lose line breaks and indentation for all content that followed the boolean value.